### PR TITLE
Add audio sink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY : clean all install
 
 TARGET = libgr_rtl_radio.so
-TARGET_RECEIVER = udp_receiver
 DESTDIR ?= /usr/local
 
 LIBS = -lgnuradio-runtime \
@@ -25,15 +24,13 @@ SOURCES = $(shell echo ./src/*.cpp)
 HEADERS = $(shell echo ./include*.h)
 OBJECTS = $(SOURCES:.cpp=.o)
 
-all: $(TARGET) $(TARGET_RECEIVER)
+all: $(TARGET)
 
 install: all
 	install -d ${DESTDIR}/lib; \
 	install -d ${DESTDIR}/include; \
 	install -m 0644 ${TARGET}  ${DESTDIR}/lib; \
 	install -m 0644 ${DEV_HDR}  ${DESTDIR}/include;
-
-$(TARGET_RECEIVER): 
 
 $(TARGET): $(OBJECTS)
 	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY : clean all install
 
 TARGET = libgr_rtl_radio.so
+TARGET_RECEIVER = udp_receiver
 DESTDIR ?= /usr/local
 
 LIBS = -lgnuradio-runtime \
@@ -24,13 +25,15 @@ SOURCES = $(shell echo ./src/*.cpp)
 HEADERS = $(shell echo ./include*.h)
 OBJECTS = $(SOURCES:.cpp=.o)
 
-all: $(TARGET)
+all: $(TARGET) $(TARGET_RECEIVER)
 
 install: all
 	install -d ${DESTDIR}/lib; \
 	install -d ${DESTDIR}/include; \
 	install -m 0644 ${TARGET}  ${DESTDIR}/lib; \
 	install -m 0644 ${DEV_HDR}  ${DESTDIR}/include;
+
+$(TARGET_RECEIVER): 
 
 $(TARGET): $(OBJECTS)
 	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -24,8 +24,6 @@ void rtl_destroy_tuner(rtl_ctx_t* this_tuner);
 
 void rtl_add_audio_sink(rtl_ctx_t* this_tuner);
 void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name);
-void rtl_add_udp_sink(rtl_ctx_t* this_tuner, const char* host, int port);
-
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);
 void rtl_stop_fm(rtl_ctx_t* this_tuner);
@@ -34,7 +32,6 @@ unsigned int rtl_get_fm_stations(rtl_ctx_t* this_tuner, double* stations_out);
 
 void rtl_set_fm(rtl_ctx_t* this_tuner, double freq);
 double rtl_get_fm(rtl_ctx_t* this_tuner);
-
 
 #ifdef __cplusplus
 }

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -19,8 +19,13 @@ typedef enum {
 // Opaque context to pass to C
 typedef struct rtl_ctx rtl_ctx_t;
 
-rtl_ctx_t* rtl_create_tuner(audio_sink_t sink);
+rtl_ctx_t* rtl_create_tuner();
 void rtl_destroy_tuner(rtl_ctx_t* this_tuner);
+
+void rtl_add_audio_sink(rtl_ctx_t* this_tuner);
+void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name);
+void rtl_add_udp_sink(rtl_ctx_t* this_tuner, const char* host, int port);
+
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);
 void rtl_stop_fm(rtl_ctx_t* this_tuner);

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -9,13 +9,6 @@
 extern "C" {
 #endif
 
-// Types of audio sinks that the tuner will send samples to
-typedef enum {
-    SINK_ALSA,
-    SINK_WAV,
-    SINK_UDP
-} audio_sink_t;
-
 // Opaque context to pass to C
 typedef struct rtl_ctx rtl_ctx_t;
 

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -9,10 +9,17 @@
 extern "C" {
 #endif
 
+// Types of audio sinks that the tuner will send samples to
+typedef enum {
+    SINK_ALSA,
+    SINK_WAV,
+    SINK_UDP
+} audio_sink_t;
+
 // Opaque context to pass to C
 typedef struct rtl_ctx rtl_ctx_t;
 
-rtl_ctx_t* rtl_create_tuner();
+rtl_ctx_t* rtl_create_tuner(audio_sink_t sink);
 void rtl_destroy_tuner(rtl_ctx_t* this_tuner);
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);
@@ -22,6 +29,7 @@ unsigned int rtl_get_fm_stations(rtl_ctx_t* this_tuner, double* stations_out);
 
 void rtl_set_fm(rtl_ctx_t* this_tuner, double freq);
 double rtl_get_fm(rtl_ctx_t* this_tuner);
+
 
 #ifdef __cplusplus
 }

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -22,7 +22,7 @@ typedef struct rtl_ctx rtl_ctx_t;
 rtl_ctx_t* rtl_create_tuner();
 void rtl_destroy_tuner(rtl_ctx_t* this_tuner);
 
-void rtl_add_audio_sink(rtl_ctx_t* this_tuner);
+void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device);
 void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name);
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -24,13 +24,12 @@
 #include "gnuradio/filter/firdes.h"
 #include "gnuradio/audio/sink.h"
 #include "gnuradio/block.h"
-#include "gnuradio/blocks/udp_sink.h"
+#include "gnuradio/blocks/wavfile_sink.h"
 #include "gnuradio/hier_block2.h"
 #include "gnuradio/gr_complex.h"
 #include "gnuradio/analog/quadrature_demod_cf.h"
 #include "gnuradio/filter/iir_filter_ffd.h"
 #include "gnuradio/filter/fir_filter_fff.h"
-#include "gnuradio/blocks/wavfile_source.h"
 #include "gnuradio/analog/probe_avg_mag_sqrd_c.h"
 #include "gr_wfmrcv.h"
 
@@ -275,9 +274,6 @@ void create_fm_device(rtl_ctx &context)
     gr::analog::probe_avg_mag_sqrd_c::sptr mag_probe = gr::analog::probe_avg_mag_sqrd_c::make(0.0);
     context.avg_magnitude = mag_probe;
 
-    /*gr::blocks::wavfile_source::sptr filesink = gr::blocks::wavfile_source::make(
-        "/home/jlruser/yocto/qcom-linux-guest/apps_proc/audio/mm-audio/audio-listen/sva/res/raw/succeed.wav"
-    );*/
 
     tb->connect(
         rtlsrc, 0,
@@ -314,33 +310,17 @@ void rtl_add_audio_sink(rtl_ctx_t* this_tuner) {
 }
 
 void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name) {
-    /*gr::blocks::wavfile_source::sptr filesink = gr::blocks::wavfile_source::make(
-        "/home/jlruser/yocto/qcom-linux-guest/apps_proc/audio/mm-audio/audio-listen/sva/res/raw/succeed.wav"
-    );*/
-    std::cout << "WAV file sinks are not supported yet" << std::endl;
-}
-
-void rtl_add_udp_sink(rtl_ctx_t* this_tuner, const char* host, int port) {
-    std::cout << "Attempting to create udp sink to " << host << ":" << port << std::endl;
-
-    if (host == NULL) {
-        std::cout << "No host provided for UDP sink" << std::endl;
-        return;
-    }
-
-    std::string str_host(host);
-
-    gr::blocks::udp_sink::sptr udp =
-        gr::blocks::udp_sink::make(
-            sizeof(float),
-            str_host,
-            port);
+    gr::blocks::wavfile_sink::sptr filesink = gr::blocks::wavfile_sink::make(
+        file_name,
+        1,
+        44100
+    );
 
     this_tuner->top_block->connect(
         this_tuner->rresamp0, 0,
-        udp, 0);
+        filesink, 0);
 
-    this_tuner->sinks.push_back(udp);
+    this_tuner->sinks.push_back(filesink);
 }
 
 // Creates and allocates an instance of an rtl tuner context.

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -117,7 +117,7 @@ unsigned int rtl_get_fm_stations(rtl_ctx_t* tuner, double* stations_out) {
 // Does all of the heavy listing setting up a flowgraph for an rtl_sdr radio source
 // @parame context Reference to the tuner context.  This is a struct and not a class because
 // the rtl_ctx is typedefed to an opaque type in the header to allow compatibility with C
-void create_fm_device(rtl_ctx &context)
+void create_fm_device(rtl_ctx &context, audio_sink_t sink_type)
 {
     int mltpl = 1e6;
     int volume = 20;
@@ -305,7 +305,7 @@ void create_fm_device(rtl_ctx &context)
 // Creates and allocates an instance of an rtl tuner context.
 // Part of the external API
 // @return A pointer to a newly allocated tuner context
-rtl_ctx_t* rtl_create_tuner()
+rtl_ctx_t* rtl_create_tuner(audio_sink_t sink_type)
 {
     rtl_ctx_t* tuner_ctx = new rtl_ctx_t;
     if (tuner_ctx == NULL)
@@ -313,7 +313,7 @@ rtl_ctx_t* rtl_create_tuner()
         printf("Error: rtl_create_tuner - out of memory\n");
         return NULL;
     }
-    create_fm_device(*tuner_ctx);
+    create_fm_device(*tuner_ctx, sink_type);
 
     return tuner_ctx;
 }

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -23,7 +23,6 @@
 #include "gnuradio/filter/fir_filter_ccf.h"
 #include "gnuradio/filter/firdes.h"
 #include "gnuradio/audio/sink.h"
-#include "gnuradio/block.h"
 #include "gnuradio/blocks/wavfile_sink.h"
 #include "gnuradio/hier_block2.h"
 #include "gnuradio/gr_complex.h"
@@ -122,15 +121,12 @@ unsigned int rtl_get_fm_stations(rtl_ctx_t* tuner, double* stations_out) {
 // the rtl_ctx is typedefed to an opaque type in the header to allow compatibility with C
 void create_fm_device(rtl_ctx &context)
 {
-    // int mltpl = 1e6;
-    // int volume = 20;
     int transition = 1e6;
     int samp_rate = 2e6;
     int quadrature = 500e3;
     double freq = 101.9;
     int cutoff = 100e3;
     int audio_dec = 10;
-    // int max_dev = 75e3;
 
     gr::top_block_sptr tb = gr::make_top_block("top");
     osmosdr::source::sptr rtlsrc = osmosdr::source::make("numchan=1 rtl=0");
@@ -268,9 +264,6 @@ void create_fm_device(rtl_ctx &context)
         gr::io_signature::make(1, 1, sizeof(gr_complex)),
         gr::io_signature::make(1, 1, sizeof(float)));
 
-    // float fm_demod_gain = quadrature / (2 * M_PI * max_dev);
-    // float audio_rate = quadrature / audio_dec;
-
     gr::analog::probe_avg_mag_sqrd_c::sptr mag_probe = gr::analog::probe_avg_mag_sqrd_c::make(0.0);
     context.avg_magnitude = mag_probe;
 
@@ -296,7 +289,7 @@ void create_fm_device(rtl_ctx &context)
         context.rresamp0, 0);
 
     // Sinks are defined in separate methods
-    printf("gr_rtl: things are connected\n");
+    printf("gr_rtl: flowgraph is connected\n");
 }
 
 void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device) {

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -300,7 +300,7 @@ void create_fm_device(rtl_ctx &context)
         context.rresamp0, 0);
 
     // Sinks are defined in separate methods
-
+    printf("gr_rtl: things are connected\n");
 }
 
 void rtl_add_audio_sink(rtl_ctx_t* this_tuner) {
@@ -332,7 +332,7 @@ void rtl_add_udp_sink(rtl_ctx_t* this_tuner, const char* host, int port) {
 
     gr::blocks::udp_sink::sptr udp =
         gr::blocks::udp_sink::make(
-            1,
+            sizeof(float),
             str_host,
             port);
 
@@ -348,6 +348,7 @@ void rtl_add_udp_sink(rtl_ctx_t* this_tuner, const char* host, int port) {
 // @return A pointer to a newly allocated tuner context
 rtl_ctx_t* rtl_create_tuner()
 {
+    printf("gr_rtl: create_tuner\n");
     rtl_ctx_t* tuner_ctx = new rtl_ctx_t;
     if (tuner_ctx == NULL)
     {

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -299,8 +299,8 @@ void create_fm_device(rtl_ctx &context)
     printf("gr_rtl: things are connected\n");
 }
 
-void rtl_add_audio_sink(rtl_ctx_t* this_tuner) {
-    gr::audio::sink::sptr audsink = gr::audio::sink::make(44100);
+void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device) {
+    gr::audio::sink::sptr audsink = gr::audio::sink::make(44100, device);
 
     this_tuner->top_block->connect(
         this_tuner->rresamp0, 0,


### PR DESCRIPTION
Refactors the gr_rtl_radio flowgraph to support multiple sink blocks.  This was done to add support for specifying a particular audio subdevice in ALSA.