### PR TITLE
Add sampling rate params to tuner API

### DIFF
--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -15,8 +15,8 @@ typedef struct rtl_ctx rtl_ctx_t;
 rtl_ctx_t* rtl_create_tuner();
 void rtl_destroy_tuner(rtl_ctx_t* this_tuner);
 
-void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device);
-void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name);
+void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device, int sampling_rate);
+void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name, int sampling_rate);
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);
 void rtl_stop_fm(rtl_ctx_t* this_tuner);

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -292,8 +292,8 @@ void create_fm_device(rtl_ctx &context)
     printf("gr_rtl: flowgraph is connected\n");
 }
 
-void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device) {
-    gr::audio::sink::sptr audsink = gr::audio::sink::make(44100, device);
+void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device, int sampling_rate) {
+    gr::audio::sink::sptr audsink = gr::audio::sink::make(sampling_rate, device);
 
     this_tuner->top_block->connect(
         this_tuner->rresamp0, 0,
@@ -302,11 +302,11 @@ void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device) {
     this_tuner->sinks.push_back(audsink);
 }
 
-void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name) {
+void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name, int sampling_rate) {
     gr::blocks::wavfile_sink::sptr filesink = gr::blocks::wavfile_sink::make(
         file_name,
         1,
-        44100
+        sampling_rate
     );
 
     this_tuner->top_block->connect(


### PR DESCRIPTION
The tuner API needs to support sound cards with different sampling rates.