### PR TITLE
Get signal str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Doxygen
 *.in
+
+# Tags
+*tags

--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -36,6 +36,8 @@ unsigned int rtl_get_fm_stations(rtl_ctx_t* this_tuner, station_info_t* stations
 void rtl_set_fm(rtl_ctx_t* this_tuner, double freq);
 double rtl_get_fm(rtl_ctx_t* this_tuner);
 
+float rtl_get_signal_str(rtl_ctx_t* tuner);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -411,6 +411,5 @@ void rtl_stop_fm(rtl_ctx_t* tuner)
 // @return A float for the FM signal strength
 float rtl_get_signal_str(rtl_ctx_t* tuner)
 {
-    printf("rtl_get_signal_str - signal strength: %f\n", tuner->avg_magnitude->level());
     return tuner->avg_magnitude->level();
 }

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -404,3 +404,13 @@ void rtl_stop_fm(rtl_ctx_t* tuner)
 
     tuner->top_block->stop();
 }
+
+// Returns the signal strength of the current fm station
+// Part of the external API
+// @param tuner The tuner context
+// @return A float for the FM signal strength
+float rtl_get_signal_str(rtl_ctx_t* tuner)
+{
+    printf("rtl_get_signal_str - signal strength: %f\n", tuner->avg_magnitude->level());
+    return tuner->avg_magnitude->level();
+}


### PR DESCRIPTION
Add API function to get the signal strength of the current FM station.  If the tuner is not running it simply returns 0.