### PR TITLE
Split out the tuner start and thread wait functions

### DIFF
--- a/include/gr_rtl_tuner.h
+++ b/include/gr_rtl_tuner.h
@@ -30,6 +30,7 @@ void rtl_add_wav_sink(rtl_ctx_t* this_tuner, const char* file_name, int sampling
 
 void rtl_start_fm(rtl_ctx_t* this_tuner);
 void rtl_stop_fm(rtl_ctx_t* this_tuner);
+void rtl_wait(rtl_ctx_t* tuner);
 
 unsigned int rtl_get_fm_stations(rtl_ctx_t* this_tuner, station_info_t* stations_out);
 

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -387,6 +387,18 @@ void rtl_start_fm(rtl_ctx_t* tuner)
         return;
     }
 
+}
+
+// Wait for the gnuradio threads to terminate
+// Part of the external API
+// @param tuner The tuner context
+void rtl_wait(rtl_ctx_t* tuner)
+{
+    if (tuner == NULL)
+    {
+        return;
+    }
+
     tuner->top_block->start();
     tuner->top_block->wait();
 }

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -387,6 +387,7 @@ void rtl_start_fm(rtl_ctx_t* tuner)
         return;
     }
 
+    tuner->top_block->start();
 }
 
 // Wait for the gnuradio threads to terminate
@@ -399,7 +400,6 @@ void rtl_wait(rtl_ctx_t* tuner)
         return;
     }
 
-    tuner->top_block->start();
     tuner->top_block->wait();
 }
 

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -369,8 +369,9 @@ void rtl_destroy_tuner(rtl_ctx_t* tuner)
     delete tuner;
 }
 
-// Starts up a tuner context running.  Blocks forever since the flowgraph never terminates.
-// The assumption is that the caller will start this function on a dedicated thread because it blocks
+// Starts up a tuner context running.  Intended to be used with rtl_wait() since rtl_start_fm is nonblocking.
+// The assumption is that the caller will start this function on a dedicated thread and
+// then that thread will call rtl_wait to block until terminated by a different thread.
 // Part of the external API
 // @param tuner The tuner context
 void rtl_start_fm(rtl_ctx_t* tuner)
@@ -390,7 +391,8 @@ void rtl_start_fm(rtl_ctx_t* tuner)
     tuner->top_block->start();
 }
 
-// Wait for the gnuradio threads to terminate
+// Blocks until the tuner is stopped from a different thread.  The flowgraph this was
+// designed for generally run forever and need to be stopped asynchronously.
 // Part of the external API
 // @param tuner The tuner context
 void rtl_wait(rtl_ctx_t* tuner)


### PR DESCRIPTION
Split out start and wait to allow for mutex signaling during testing.  This allows a signal to be sent by a caller in between starting the tuner and blocking on the gnuradio top_block.