### PR TITLE
add exception handing to rtl_add_audio_sink call

### DIFF
--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -315,6 +315,13 @@ void create_fm_device(rtl_ctx &context)
 
 void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device, int sampling_rate) {
     gr::audio::sink::sptr audsink = gr::audio::sink::make(sampling_rate, device);
+    try {
+        audsink = gr::audio::sink::make(sampling_rate, device);
+    } catch(...) {
+        // code to handle any exception
+        printf("Exception Caught: rtl_add_audio_sink - invalid audio sinks device\n");
+        return;
+    }
 
     this_tuner->top_block->connect(
         this_tuner->rresamp0, 0,

--- a/src/gr_rtl_tuner.cpp
+++ b/src/gr_rtl_tuner.cpp
@@ -314,7 +314,7 @@ void create_fm_device(rtl_ctx &context)
 }
 
 void rtl_add_audio_sink(rtl_ctx_t* this_tuner, const char* device, int sampling_rate) {
-    gr::audio::sink::sptr audsink = gr::audio::sink::make(sampling_rate, device);
+    gr::audio::sink::sptr audsink = NULL;
     try {
         audsink = gr::audio::sink::make(sampling_rate, device);
     } catch(...) {


### PR DESCRIPTION
added exception handling to rtl_add_audio_sink call in order to prevent system hang if an invalided  an ALSA audio sink specified.